### PR TITLE
new feature: default column headers can now have different naming methods 

### DIFF
--- a/lib/column-name.coffee
+++ b/lib/column-name.coffee
@@ -2,10 +2,10 @@
 namingMethod=atom.config.get('tablr.defaultColumnNamingMethod')
 module.exports =
 columnName = (index) ->
-  if atom.config.get('tablr.defaultColumnNamingMethod') == 'numeric'
-    (1+index) + ''
-  else if atom.config.get('tablr.defaultColumnNamingMethod') == 'numericZeroBased'
-    index + ''
+  if namingMethod is 'numeric'
+    String(1+index)
+  else if namingMethod is 'numericZeroBased'
+    String(index)
   else
     base = 'A B C D E F G H I J K L M N O P Q R S T U V W X Y Z'.split(' ')
 

--- a/lib/column-name.coffee
+++ b/lib/column-name.coffee
@@ -1,4 +1,5 @@
 
+namingMethod=atom.config.get('tablr.defaultColumnNamingMethod')
 module.exports =
 columnName = (index) ->
   if atom.config.get('tablr.defaultColumnNamingMethod') == 'numeric'

--- a/lib/column-name.coffee
+++ b/lib/column-name.coffee
@@ -1,11 +1,16 @@
 
 module.exports =
 columnName = (index) ->
-  base = 'A B C D E F G H I J K L M N O P Q R S T U V W X Y Z'.split(' ')
-
-  quotient = Math.floor(index / 26)
-
-  if quotient > 0
-    columnName(quotient - 1) + base[index % 26]
+  if atom.config.get('tablr.defaultColumnNamingMethod') == 'numeric'
+    (1+index) + ''
+  else if atom.config.get('tablr.defaultColumnNamingMethod') == 'numericZeroBased'
+    index + ''
   else
-    base[index % 26]
+    base = 'A B C D E F G H I J K L M N O P Q R S T U V W X Y Z'.split(' ')
+
+    quotient = Math.floor(index / 26)
+
+    if quotient > 0
+      columnName(quotient - 1) + base[index % 26]
+    else
+      base[index % 26]

--- a/lib/tablr.coffee
+++ b/lib/tablr.coffee
@@ -81,7 +81,7 @@ module.exports =
       type: 'string'
       default: 'alphabetic'
       enum: ['alphabetic', 'numeric', 'numericZeroBased']
-      description: 'When file has no header, select the default naming method for the columns. `alphabetic` means use A, B,..., Z, AA, AB.. `numeric` is for simple numbers, ie 1,2.. `numericZeroBased` is similar as numeric, except that it starts numbering from 0 instead of 1'
+      description: 'When file has no header, select the default naming method for the columns. `alphabetic` means use A, B,..., Z, AA, AB.. `numeric` is for simple numbers, ie 1,2.. `numericZeroBased` is similar to "numeric", except that it starts numbering from 0 instead of 1'
 
   activate: ({csvConfig}) ->
     @csvConfig = new CSVConfig(csvConfig)

--- a/lib/tablr.coffee
+++ b/lib/tablr.coffee
@@ -73,11 +73,15 @@ module.exports =
       type: 'boolean'
       default: true
       description: 'When copying from a table to paste the content in a text editor this setting will make each cell appear as if they were created from different selections.'
-
     supportedCsvExtensions:
       type: 'array'
       default: ['csv', 'tsv']
       description: 'The extensions for which the CSV opener will be used.'
+    defaultColumnNamingMethod:
+      type: 'string'
+      default: 'alphabetic'
+      enum: ['alphabetic', 'numeric', 'numericZeroBased']
+      description: 'When file has no header, select the default naming method for the columns. `alphabetic` means use A, B,..., Z, AA, AB.. `numeric` is for simple numbers, ie 1,2.. `numericZeroBased` is similar as numeric, except that it starts numbering from 0 instead of 1'
 
   activate: ({csvConfig}) ->
     @csvConfig = new CSVConfig(csvConfig)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tablr",
   "main": "./lib/tablr",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Edit CSV files using a table editor",
   "repository": "https://github.com/abe33/atom-tablr",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tablr",
   "main": "./lib/tablr",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "description": "Edit CSV files using a table editor",
   "repository": "https://github.com/abe33/atom-tablr",
   "license": "MIT",


### PR DESCRIPTION
I am editing a 130+ columns file whose column definition is in a separate file, with numeric indexes. converting "EC" to 133 was not straight forward :)