### PR TITLE
Added an option for disabling preview of the table in the csv-editor-element

### DIFF
--- a/lib/csv-editor-element.coffee
+++ b/lib/csv-editor-element.coffee
@@ -121,7 +121,7 @@ class CSVEditorElement extends HTMLElement
     delete @formContainer
 
   updatePreview: (options) ->
-    return if options.remember
+    return if options.remember or atom.config.get('tablr.disablePreview')
 
     @form.preview.clean()
     @model.previewCSV(options).then (preview) =>

--- a/lib/tablr.coffee
+++ b/lib/tablr.coffee
@@ -171,6 +171,13 @@ module.exports =
       type: 'array'
       default: ['csv', 'tsv', 'CSV', 'TSV']
       description: 'The extensions for which the CSV opener will be used.'
+      
+    disablePreview:
+      title: 'Disable preview'
+      description: 'When checked, preview will not be presented.'
+      type: 'boolean'
+      default: false
+      
     defaultColumnNamingMethod:
       type: 'string'
       default: 'alphabetic'


### PR DESCRIPTION
This is useful when opening very large files on slower machines