### PR TITLE
update link of csv editor

### DIFF
--- a/docs/tablr-api.md
+++ b/docs/tablr-api.md
@@ -110,4 +110,4 @@ readFile(filePath, data => {
 
 Now our table editor can be modified and saved on disk at any time.
 
-If you want to see a more concrete example, you can take a look to the [CSVEditor class](https://github.com/abe33/atom-tablr/blob/master/lib/csv-editor.coffee) and [its test suite](https://github.com/abe33/atom-tablr/blob/master/spec/csv-editor-spec.coffee).
+If you want to see a more concrete example, you can take a look to the [CSVEditor class](https://github.com/abe33/atom-tablr/blob/master/lib/csv-editor.js) and [its test suite](https://github.com/abe33/atom-tablr/blob/master/spec/csv-editor-spec.coffee).


### PR DESCRIPTION
Sorry, I'm not seeing the "Git Commit Messages" section of [Atom contribution guidelines.](https://flight-manual.atom.io/) referenced in https://github.com/abe33/atom-tablr/blob/master/CONTRIBUTING.md.  Maybe something int he document changed.