### PR TITLE
fix "Cannot read property includeInto of undefined" error

### DIFF
--- a/lib/mixins/pool.js
+++ b/lib/mixins/pool.js
@@ -12,7 +12,7 @@ module.exports = class Pool {
     const Singular = capitalize(singular)
     const Plural = capitalize(plural)
 
-    const source = `class ${Plural}Pool extends Mixin {
+    const source = `(class ${Plural}Pool extends Mixin {
       init${Plural}Pool (${plural}Class, ${plural}Container) {
         this.${plural}Class = ${plural}Class
         this.${plural}Container = ${plural}Container
@@ -56,13 +56,10 @@ module.exports = class Pool {
         this.used${Plural} = []
         return this.unused${Plural} = []
       }
-    }
-    ${Plural}Pool`
+    })`
 
     const sandbox = {Mixin, atom, console}
-    const context = vm.createContext(sandbox)
-
-    const mixin = vm.runInContext(source, context, `${plural}-pool.vm`)
+    const mixin = vm.runInNewContext(source, sandbox, `${plural}-pool.vm`)
     mixin.includeInto(this)
   }
 }

--- a/lib/mixins/pool.js
+++ b/lib/mixins/pool.js
@@ -56,7 +56,8 @@ module.exports = class Pool {
         this.used${Plural} = []
         return this.unused${Plural} = []
       }
-    }`
+    }
+    ${Plural}Pool`
 
     const sandbox = {Mixin, atom, console}
     const context = vm.createContext(sandbox)


### PR DESCRIPTION
This fixes an error in `pool.js` that causes an error message "Cannot read property includeInto of undefined" (and no table) to appear when opening csv/tsv files with the Table Editor. 

It appears that `vm.runInContext()` does not return a copy of the class when called with an ES6 class declaration, although it may have returned a copy of the class when called with a coffescript class declaration in the past. This pull request refers to the class at the end of the source code, which causes `vm.runInContext()` to return the class instead of `undefined`. This prevents the error noted above.

This fixes issues #100 and #101.